### PR TITLE
Add test file prefix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The extension also supports multiple templates, by using on an object. When you 
 * `createTest.testFolder`: path to the test folder, if the string starts with `./` it will be search relative to the opened file, default is `"test"`
 * `createTest.testFileExtension`: the file extension of the tests, default is `".spec.js"`
 * `createTest.srcFileExtension`: the file extension of the source files, default is `".js"`
+* `createTest.testFilePrefix`: the file prefix of the test file, default is `""`
 * `createTest.testFileTemplate`: the template for the new created test, default is `["import ${moduleName} from '${modulePath}'"]`
 * `myExtension.srcFolder`: remove the source folder from the test file path
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
                     "type": "string",
                     "default": ".js",
                     "description": "source file extension"
+                },
+                "createTest.testFilePrefix": {
+                    "type": "string",
+                    "default": "",
+                    "description": "test file prefix"
                 }
             }
         },

--- a/src/pathUtils.ts
+++ b/src/pathUtils.ts
@@ -61,10 +61,17 @@ const name = (p, ext) => p.basename(ext)
 
 export const pathToFile = (uri: Uri, workSpaceUri: Uri, config) => {
     const _isTestModule = isTestModule(uri, workSpaceUri, config)
-    const basename = name(
+    let basename = name(
         pathFromUri(uri),
         _isTestModule ? config.testFileExtension : config.srcFileExtension
     )
+    if (config.testFilePrefix) {
+        if (_isTestModule) {
+            basename = basename.replace(new RegExp(`^${config.testFilePrefix}`), '')
+        } else {
+            basename = config.testFilePrefix + basename
+        }
+    }
     const extname = _isTestModule
         ? config.srcFileExtension
         : config.testFileExtension


### PR DESCRIPTION
Thank you for the great tool!

I whould lile to use this extension for a Python project which has a project structure like [this](https://stackoverflow.com/questions/67057865/reduce-cognitive-load-to-create-test-foo-py).

This PR is Add support test file prefix.

The new config `createTest.testFilePrefix` is to specify the file prefix like `_test`. The default value is an empty string.
